### PR TITLE
Naoyuki

### DIFF
--- a/backend/django_app/api/templates/recipe_list.html
+++ b/backend/django_app/api/templates/recipe_list.html
@@ -7,6 +7,7 @@
 <div class='card'>
     <h5 class='card-header'>{{ item.recipe_name }}</h5>
     <div class='card-body'>
+        <p class='card-text'>{{ item.user_id }}</p>
         <p class='card-text'>{{ item.data_url }}</p>
         <h6 class="card-title">{{ item.memo }}</h6>
     </div>

--- a/backend/django_app/api/urls.py
+++ b/backend/django_app/api/urls.py
@@ -2,8 +2,9 @@ from django.urls import include, path
 from . import views
 
 urlpatterns = [
-    path('recipes/', views.RecipeView.as_view(), name='list-recipe'),
+    path('recipes/',views.RecipeView.as_view(), name='list-recipe'),
     path('create/',views.CreateRecipe.as_view(), name='create-recipe'),
     path('<int:pk>/delete',views.DeleteRecipe.as_view(),name='delete-recipe'),
     path('<int:pk>/update/',views.UpdateRecipe.as_view(),name='update-recipi'),
+    path('list',views.recipe_list),
 ]

--- a/backend/django_app/api/views.py
+++ b/backend/django_app/api/views.py
@@ -2,7 +2,10 @@ from django.shortcuts import render
 from django.urls import reverse_lazy
 from django.views.generic import ListView, CreateView, DeleteView, UpdateView
 from .models import Recipes
-# Create your views here.
+from django.shortcuts import render, get_list_or_404
+from django.contrib import sessions
+
+
 class RecipeView(ListView):
     template_name = 'recipe_list.html'
     model = Recipes
@@ -28,4 +31,10 @@ class UpdateRecipe(UpdateView):
 
 from django.shortcuts import render
 
-# Create your views here.
+
+def recipe_list(request):
+
+    uid = request.user.id
+    recipes_list = get_list_or_404(Recipes, user_id=uid) 
+    template_name = 'recipe_list.html'
+    return render(request, template_name,{'object_list': recipes_list})

--- a/backend/django_app/django_app/settings.py
+++ b/backend/django_app/django_app/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.shortcuts",
     "rest_framework",
     "rest_framework.authtoken",
     "accounts",
@@ -73,7 +74,7 @@ ROOT_URLCONF = "django_app.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / 'templates'],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -146,7 +147,7 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # なおゆきコメント：サーバー起動時のエラー表示回避のため、リダイレクトを仮で指定
-LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL = "recipes/list"
 LOGOUT_REDIRECT_URL = "rest_framework:login"
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [

--- a/backend/django_app/django_app/urls.py
+++ b/backend/django_app/django_app/urls.py
@@ -7,7 +7,7 @@ from api import urls
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
-    path("recipes/",include("api.urls")),
+    path("api-auth/login/recipes/",include("api.urls")),
     path("", include("accounts.urls")),
     
     # path("api/", include('router.urls')),


### PR DESCRIPTION
以下の仕様に変更しています。
1.ログイン後のレシピ一覧ページの変更
　before:全ユーザーのレシピを表示
　atrer:ログインユーザーのレシピに限定し表示
2.レシピ表示URLの階層を変更
　before:レシピ表示は/recipes/recipes/でログイン情報を使えないURLだった。
　after:レシピ表示は/api-auth/login/recipes/listでログイン情報を使用できるようにした。