### PR TITLE
apiとルーティングを整理

### DIFF
--- a/backend/django_app/accounts/urls.py
+++ b/backend/django_app/accounts/urls.py
@@ -5,14 +5,14 @@ import rest_framework.authtoken.views as auth_views
 from rest_framework import routers, urls
 from .views import CreateUserView  # , UserViewSet
 
-"""
-views.pyのUserViewsetを有効にした後で有効化の予定
 
-router = routers.DefaultRouter()
-router.register("users",UserViewSet)
-"""
+# views.pyのUserViewsetを有効にした後で有効化の予定
+
+# router = routers.DefaultRouter()
+# router.register("users",UserViewSet)
+
 
 urlpatterns = [
     path("signup/", CreateUserView.as_view(), name="signup"),
-    path("login", include("rest_framework.urls")),
+    # path("login/", include("rest_framework.urls")),
 ]

--- a/backend/django_app/accounts/views.py
+++ b/backend/django_app/accounts/views.py
@@ -17,11 +17,11 @@ class CreateUserView(APIView):
 
 
 # トークン認証
-"""なおゆきコメント：silializer.pyを作成した後、以下を有効にする。
+# なおゆきコメント：silializer.pyを作成した後、以下を有効にする。
 
- class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-    authentication_classes = (TokenAuthentication,)
-    permission_classes = (IsAuthenticated, )
-"""
+#  class UserViewSet(viewsets.ModelViewSet):
+#     queryset = User.objects.all()
+#     serializer_class = UserSerializer
+#     authentication_classes = (TokenAuthentication,)
+#     permission_classes = (IsAuthenticated, )
+

--- a/backend/django_app/api/serializers.py
+++ b/backend/django_app/api/serializers.py
@@ -7,7 +7,7 @@ class RecipeSerializer(serializers.ModelSerializer):
         model = Recipe
         fields = [
             "id",
-            "user_id",
+            # "user_id",
             "recipe_name",
             "data_url",
             "memo",
@@ -18,3 +18,5 @@ class RecipeSerializer(serializers.ModelSerializer):
             "genre_tag",
             "jitan_tag",
         ]
+        extra_kwargs = {"user_id": {"write_only": True}}
+

--- a/backend/django_app/api/urls.py
+++ b/backend/django_app/api/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 urlpatterns = [
     path("recipes/", views.RecipeList.as_view(), name="recipe-list"),
+    path("create/", views.CreateRecipe.as_view(), name="create-recipe"),
     path("recipes/<int:pk>/", views.RecipeDetail.as_view(), name="recipe-detail"),
 ]

--- a/backend/django_app/api/views.py
+++ b/backend/django_app/api/views.py
@@ -3,6 +3,8 @@ from .serializers import RecipeSerializer
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.authentication import TokenAuthentication
+from django.urls import reverse_lazy
 
 
 class RecipeList(generics.ListAPIView):
@@ -14,17 +16,41 @@ class RecipeList(generics.ListAPIView):
         return Recipe.objects.filter(user_id=user.id)
 
 
+# class RecipeDetail(generics.RetrieveUpdateDestroyAPIView):
+#     serializer_class = RecipeSerializer
+#     permission_classes = [IsAuthenticated]
+
+#     def get_queryset(self):
+#         return Recipe.objects.filter(user_id=self.request.user.id)
+
+#     def get_object(self):
+#         obj = super().get_object()
+
+#         if obj.user != self.request.user:
+#             raise PermissionDenied("この操作は許可されていません。")
+
+#         return obj
+"""
+レシピ登録でuser_idを含めなくてもtokenから判定し自動でセットされるようserializers.pyを修正しました。ただ、そうすると
+既存のレシピ詳細コードではエラーが出てしまいました。以下のコードにすると、user_idはログイン中のものが自動で付与され、
+URLに別のユーザーのレシピIDをセットすると「見つかりませんでした」を返します。こんな感じでどうでしょうか？
+"""
 class RecipeDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Recipe.objects.all()
     serializer_class = RecipeSerializer
-    permission_classes = [IsAuthenticated]
-
     def get_queryset(self):
-        return Recipe.objects.filter(user_id=self.request.user.id)
+        user = self.request.user
+        return Recipe.objects.filter(user_id=user.id)
 
-    def get_object(self):
-        obj = super().get_object()
 
-        if obj.user != self.request.user:
-            raise PermissionDenied("この操作は許可されていません。")
+class CreateRecipe(generics.CreateAPIView):
+    queryset = Recipe.objects.all()
+    serializer_class = RecipeSerializer
+    authentication_classes = (TokenAuthentication,)  # トークン認証を有効化
+    permission_classes = (IsAuthenticated,)  # 認証されたユーザーのみ許可
+   
+    def perform_create(self, serializer):
+        # ここでは self.request.user が認証済みユーザーのインスタンスを返す
+        serializer.save(user_id=self.request.user)
 
-        return obj
+    success_url = reverse_lazy("recipe-list")

--- a/backend/django_app/django_app/authentication.py
+++ b/backend/django_app/django_app/authentication.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+
+User = get_user_model()
+
+class EmailAuthBackend(BaseBackend):
+    """
+    メールアドレスとパスワードでの認証を行うカスタム認証バックエンド。
+    """
+
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        try:
+            user = User.objects.get(email=username)  # ユーザー名ではなくメールアドレスでユーザーを検索
+            if user.check_password(password):
+                return user
+        except User.DoesNotExist:
+            raise ValidationError("メールアドレスまたはパスワードが間違っています。")
+        return None

--- a/backend/django_app/django_app/settings.py
+++ b/backend/django_app/django_app/settings.py
@@ -124,6 +124,12 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# ログインをアドレスとパスワードで行うためのもの
+AUTHENTICATION_BACKENDS = [
+    'django_app.authentication.EmailAuthBackend',  # カスタム認証バックエンドのパス
+    'django.contrib.auth.backends.ModelBackend',  # Djangoのデフォルトの認証バックエンド
+]
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/

--- a/backend/django_app/django_app/urls.py
+++ b/backend/django_app/django_app/urls.py
@@ -5,18 +5,17 @@ from accounts import urls
 from api import urls
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("api-auth/", include("rest_framework.urls")),
-    path("api-auth/login/", include("api.urls")),
+    # path("admin/", admin.site.urls),
+    # path("api-auth/", include("rest_framework.urls")),
+    path("api/login/", include("api.urls")),
     path("", include("accounts.urls")),
     # path("api/", include('router.urls')),
     # path("api-token-auth/", views.obtain_auth_token),
 ]
 
-"""
-ユーザーがこのエンドポイントにusernameとpasswordをPOSTするとトークンを返し、
-以降、このトークンを使用して認証が必要なAPIにアクセスする。
-"""
+
+# ユーザーがこのエンドポイントにusernameとpasswordをPOSTするとトークンを返し、
+# 以降、このトークンを使用して認証が必要なAPIにアクセスする。
 urlpatterns += [
     path("api-token-auth/", obtain_auth_token, name="api_token_auth"),
 ]


### PR DESCRIPTION
・レシピ登録処理を追加
・レシピ登録・詳細表示・更新・削除においてトークンからuser_idを自動取得しセットする仕様
・ルーティングを変更。詳細は以下
サインアップ→/signup/
ログイン　　→/api-token-auth/
レシピ一覧　→/api/login/recipes/
レシピ登録　→/api/login/create/
レシピ詳細　→/api/login/recipes/<id>/
※レシピ詳細のURLはメソッドにより詳細表示/更新/削除が変化